### PR TITLE
Add atom indexes to snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ These constructor arguments are available as attributes:
 
 The data contained in a `Snapshot` per particle is:
 
+- `id`: (*N*,) array atom IDs (dtype: `numpy.float32`, default: runs from 1 to *N*)
 - `position`: (*N*,3) array of coordinates (dtype: `numpy.float64`, default: `(0,0,0)`)
 - `image`: (*N*,3) array of periodic image indexes (dtype: `numpy.int32`, default: `(0,0,0)`)
 - `velocity`: (*N*,3) array of velocities (dtype: `numpy.float64`, default: `(0,0,0)`)
@@ -85,6 +86,10 @@ Valid keys for the schema match the names and shapes in the `Snapshot`. The
 keys requiring only 1 column index are: `id`, `typeid`, `molecule`, `charge`,
 and `mass`. The keys requiring 3 column indexes are `position`, `velocity`,
 and `image`.
+
+LAMMPS will dump particles in an unknown order unless you have used the
+`dump_modify sort` option. If you want particles to be ordered by `id` in the
+`Snapshot`, use `sort_ids=True` (default).
 
 A `DumpFile` is iterable, so you can use it to go through all the snapshots
 of a trajectory:

--- a/tests/test_data_file.py
+++ b/tests/test_data_file.py
@@ -3,8 +3,11 @@ import pytest
 
 import lammpsio
 
+@pytest.mark.parametrize("shuffle_ids", [False, True])
 @pytest.mark.parametrize("atom_style", ["atomic", "molecular", "charge", "full"])
-def test_data_file_min(snap, atom_style, tmp_path):
+def test_data_file_min(snap, atom_style, shuffle_ids, tmp_path):
+    if shuffle_ids:
+        snap.id = [2, 0, 1]
     # write the data file with default values
     filename = tmp_path / "atoms.data"
     data = lammpsio.DataFile.create(filename, snap, atom_style)
@@ -20,6 +23,11 @@ def test_data_file_min(snap, atom_style, tmp_path):
         assert numpy.allclose(snap_2.box.tilt, snap.box.tilt)
     else:
         assert snap_2.box.tilt is None
+    if shuffle_ids:
+        assert snap_2.has_id()
+        assert numpy.allclose(snap_2.id, snap.id)
+    else:
+        assert not snap_2.has_id()
     assert snap_2.has_position()
     assert numpy.allclose(snap_2.position, 0)
     assert not snap_2.has_image()
@@ -38,9 +46,12 @@ def test_data_file_min(snap, atom_style, tmp_path):
     else:
         assert not snap_2.has_charge()
 
+@pytest.mark.parametrize("shuffle_ids", [False, True])
 @pytest.mark.parametrize("set_style", [True, False])
 @pytest.mark.parametrize("atom_style", ["atomic", "molecular", "charge", "full"])
-def test_data_file_all(snap, atom_style, set_style, tmp_path):
+def test_data_file_all(snap, atom_style, set_style, shuffle_ids, tmp_path):
+    if shuffle_ids:
+        snap.id = [2, 0, 1]
     # write the data file with nondefault values
     snap.position = [[0.1,0.2,0.3],[-0.4,-0.5,-0.6],[0.7,0.8,0.9]]
     snap.image = [[1,2,3],[-4,-5,-6],[7,8,9]]
@@ -65,6 +76,11 @@ def test_data_file_all(snap, atom_style, set_style, tmp_path):
         assert numpy.allclose(snap_2.box.tilt, snap.box.tilt)
     else:
         assert snap_2.box.tilt is None
+    if shuffle_ids:
+        assert snap_2.has_id()
+        assert numpy.allclose(snap_2.id, snap.id)
+    else:
+        assert not snap_2.has_id()
     assert snap_2.has_position()
     assert numpy.allclose(snap_2.position, snap.position)
     assert snap_2.has_velocity()


### PR DESCRIPTION
This PR allows the atom IDs to form a noncompact range. Previously, the code assumed that the particle IDs could be used as array indexes (after offsetting by 1), but this would lead to segfaults if only a subset of the particles were included.

The particle IDs are now a property of the `Snapshot`. The default value is the range from 1 to N (inclusive), and the IDs are only populated when nondefault IDs are used.