### PR TITLE
Add ability for dump file to copy from snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Snapshots store particle IDs. Files can contain noncompact particle ID ranges.
+- Dump file can copy fields from another snapshot during reading.
 
 ## [0.1.1] - 2022-10-21
 ### Fixed
@@ -22,5 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The package has been renamed `lammpsio` for consistency with PyPI.
 
+[Unreleased]: https://github.com/mphowardlab/lammpsio/compare/v0.1.1...HEAD
 [0.1.1]: https://github.com/mphowardlab/lammpsio/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/mphowardlab/lammpsio/releases/tag/v0.1.0

--- a/src/lammpsio/__init__.py
+++ b/src/lammpsio/__init__.py
@@ -780,9 +780,9 @@ class DumpFile:
     The dump file is a flexible file format, so a ``schema`` needs to be given
     to parse the atom data. The ``schema`` is given as a dictionary of column
     indexes. Valid keys for the schema match the names and shapes in the `Snapshot`.
-    The keys requiring only 1 column index are: `id`, `typeid`, `molecule`, `charge`,
-    and `mass`. The keys requiring 3 column indexes are `position`, `velocity`,
-    and `image`.
+    The keys requiring only 1 column index are: ``id``, ``typeid``, ``molecule``,
+    ``charge``, and ``mass``. The keys requiring 3 column indexes are ``position``,
+    ``velocity``, and ``image``.
 
     Parameters
     ----------
@@ -794,7 +794,8 @@ class DumpFile:
         If true, sort the particles by ID in each snapshot.
     copy_from : :class:`Snapshot`
         If specified, copy fields that are missing in the dump file but are set in
-        a reference :class:`Snapshot`.
+        a reference :class:`Snapshot`. The fields that can be copied are ``typeid``,
+        ``molecule``, ``charge``, and ``mass``.
 
     """
 
@@ -1071,10 +1072,10 @@ class DumpFile:
                         else:
                             copy_id = [copy_id_map[id_] for id_ in range(1, snap.N+1)]
 
-                        if not snap.has_molecule() and self._copy_from.has_molecule():
-                            snap.molecule = self._copy_from.molecule[copy_id]
                         if not snap.has_typeid() and self._copy_from.has_typeid():
                             snap.typeid = self._copy_from.typeid[copy_id]
+                        if not snap.has_molecule() and self._copy_from.has_molecule():
+                            snap.molecule = self._copy_from.molecule[copy_id]
                         if not snap.has_charge() and self._copy_from.has_charge():
                             snap.charge = self._copy_from.charge[copy_id]
                         if not snap.has_mass() and self._copy_from.has_mass():

--- a/src/lammpsio/__init__.py
+++ b/src/lammpsio/__init__.py
@@ -159,11 +159,11 @@ class Snapshot:
     @id.setter
     def id(self, value):
         if value is not None:
-            if not self.has_id():
-                self._id = numpy.arange(1, self.N+1)
             v = numpy.array(value, ndmin=1, copy=False, dtype=numpy.int32)
             if v.shape != (self.N,):
                 raise TypeError('Ids must be a size N array')
+            if not self.has_id():
+                self._id = numpy.arange(1, self.N+1)
             numpy.copyto(self._id, v)
         else:
             self._id = None
@@ -189,11 +189,11 @@ class Snapshot:
     @position.setter
     def position(self, value):
         if value is not None:
-            if not self.has_position():
-                self._position = numpy.zeros((self.N, 3), dtype=numpy.float64)
             v = numpy.array(value, ndmin=2, copy=False, dtype=numpy.float64)
             if v.shape != (self.N, 3):
                 raise TypeError('Positions must be an Nx3 array')
+            if not self.has_position():
+                self._position = numpy.zeros((self.N, 3), dtype=numpy.float64)
             numpy.copyto(self._position, v)
         else:
             self._position = None
@@ -219,11 +219,11 @@ class Snapshot:
     @image.setter
     def image(self, value):
         if value is not None:
-            if not self.has_image():
-                self._image = numpy.zeros((self.N, 3), dtype=numpy.int32)
             v = numpy.array(value, ndmin=2, copy=False, dtype=numpy.int32)
             if v.shape != (self.N, 3):
                 raise TypeError('Images must be an Nx3 array')
+            if not self.has_image():
+                self._image = numpy.zeros((self.N, 3), dtype=numpy.int32)
             numpy.copyto(self._image, v)
         else:
             self._image = None
@@ -249,11 +249,11 @@ class Snapshot:
     @velocity.setter
     def velocity(self, value):
         if value is not None:
-            if not self.has_velocity():
-                self._velocity = numpy.zeros((self.N, 3), dtype=numpy.float64)
             v = numpy.array(value, ndmin=2, copy=False, dtype=numpy.float64)
             if v.shape != (self.N, 3):
                 raise TypeError('Velocities must be an Nx3 array')
+            if not self.has_velocity():
+                self._velocity = numpy.zeros((self.N, 3), dtype=numpy.float64)
             numpy.copyto(self._velocity, v)
         else:
             self._velocity = None
@@ -279,11 +279,11 @@ class Snapshot:
     @molecule.setter
     def molecule(self, value):
         if value is not None:
-            if not self.has_molecule():
-                self._molecule = numpy.zeros(self.N, dtype=numpy.int32)
             v = numpy.array(value, ndmin=1, copy=False, dtype=numpy.int32)
             if v.shape != (self.N,):
                 raise TypeError('Molecules must be a size N array')
+            if not self.has_molecule():
+                self._molecule = numpy.zeros(self.N, dtype=numpy.int32)
             numpy.copyto(self._molecule, v)
         else:
             self._molecule = None
@@ -309,11 +309,11 @@ class Snapshot:
     @typeid.setter
     def typeid(self, value):
         if value is not None:
-            if not self.has_typeid():
-                self._typeid = numpy.ones(self.N, dtype=numpy.int32)
             v = numpy.array(value, ndmin=1, copy=False, dtype=numpy.int32)
             if v.shape != (self.N,):
                 raise TypeError('Type must be a size N array')
+            if not self.has_typeid():
+                self._typeid = numpy.ones(self.N, dtype=numpy.int32)
             numpy.copyto(self._typeid, v)
         else:
             self._typeid = None
@@ -339,11 +339,11 @@ class Snapshot:
     @charge.setter
     def charge(self, value):
         if value is not None:
-            if not self.has_charge():
-                self._charge = numpy.zeros(self.N, dtype=numpy.float64)
             v = numpy.array(value, ndmin=1, copy=False, dtype=numpy.float64)
             if v.shape != (self.N,):
                 raise TypeError('Charge must be a size N array')
+            if not self.has_charge():
+                self._charge = numpy.zeros(self.N, dtype=numpy.float64)
             numpy.copyto(self._charge, v)
         else:
             self._charge = None
@@ -369,11 +369,11 @@ class Snapshot:
     @mass.setter
     def mass(self, value):
         if value is not None:
-            if not self.has_mass():
-                self._mass = numpy.ones(self.N, dtype=numpy.float64)
             v = numpy.array(value, ndmin=1, copy=False, dtype=numpy.float64)
             if v.shape != (self.N,):
                 raise TypeError('Mass must be a size N array')
+            if not self.has_mass():
+                self._mass = numpy.ones(self.N, dtype=numpy.float64)
             numpy.copyto(self._mass, v)
         else:
             self._mass = None

--- a/src/lammpsio/__init__.py
+++ b/src/lammpsio/__init__.py
@@ -158,12 +158,15 @@ class Snapshot:
 
     @id.setter
     def id(self, value):
-        if not self.has_id():
-            self._id = numpy.arange(1, self.N+1)
-        v = numpy.array(value, ndmin=1, copy=False, dtype=numpy.int32)
-        if v.shape != (self.N,):
-            raise TypeError('Ids must be a size N array')
-        numpy.copyto(self._id, v)
+        if value is not None:
+            if not self.has_id():
+                self._id = numpy.arange(1, self.N+1)
+            v = numpy.array(value, ndmin=1, copy=False, dtype=numpy.int32)
+            if v.shape != (self.N,):
+                raise TypeError('Ids must be a size N array')
+            numpy.copyto(self._id, v)
+        else:
+            self._id = None
 
     def has_id(self):
         """Check if configuration has particle IDs.
@@ -185,12 +188,15 @@ class Snapshot:
 
     @position.setter
     def position(self, value):
-        if not self.has_position():
-            self._position = numpy.zeros((self.N, 3), dtype=numpy.float64)
-        v = numpy.array(value, ndmin=2, copy=False, dtype=numpy.float64)
-        if v.shape != (self.N, 3):
-            raise TypeError('Positions must be an Nx3 array')
-        numpy.copyto(self._position, v)
+        if value is not None:
+            if not self.has_position():
+                self._position = numpy.zeros((self.N, 3), dtype=numpy.float64)
+            v = numpy.array(value, ndmin=2, copy=False, dtype=numpy.float64)
+            if v.shape != (self.N, 3):
+                raise TypeError('Positions must be an Nx3 array')
+            numpy.copyto(self._position, v)
+        else:
+            self._position = None
 
     def has_position(self):
         """Check if configuration has positions.
@@ -212,12 +218,15 @@ class Snapshot:
 
     @image.setter
     def image(self, value):
-        if not self.has_image():
-            self._image = numpy.zeros((self.N, 3), dtype=numpy.int32)
-        v = numpy.array(value, ndmin=2, copy=False, dtype=numpy.int32)
-        if v.shape != (self.N, 3):
-            raise TypeError('Images must be an Nx3 array')
-        numpy.copyto(self._image, v)
+        if value is not None:
+            if not self.has_image():
+                self._image = numpy.zeros((self.N, 3), dtype=numpy.int32)
+            v = numpy.array(value, ndmin=2, copy=False, dtype=numpy.int32)
+            if v.shape != (self.N, 3):
+                raise TypeError('Images must be an Nx3 array')
+            numpy.copyto(self._image, v)
+        else:
+            self._image = None
 
     def has_image(self):
         """Check if configuration has images.
@@ -239,12 +248,15 @@ class Snapshot:
 
     @velocity.setter
     def velocity(self, value):
-        if not self.has_velocity():
-            self._velocity = numpy.zeros((self.N, 3), dtype=numpy.float64)
-        v = numpy.array(value, ndmin=2, copy=False, dtype=numpy.float64)
-        if v.shape != (self.N, 3):
-            raise TypeError('Velocities must be an Nx3 array')
-        numpy.copyto(self._velocity, v)
+        if value is not None:
+            if not self.has_velocity():
+                self._velocity = numpy.zeros((self.N, 3), dtype=numpy.float64)
+            v = numpy.array(value, ndmin=2, copy=False, dtype=numpy.float64)
+            if v.shape != (self.N, 3):
+                raise TypeError('Velocities must be an Nx3 array')
+            numpy.copyto(self._velocity, v)
+        else:
+            self._velocity = None
 
     def has_velocity(self):
         """Check if configuration has velocities.
@@ -266,12 +278,15 @@ class Snapshot:
 
     @molecule.setter
     def molecule(self, value):
-        if not self.has_molecule():
-            self._molecule = numpy.zeros(self.N, dtype=numpy.int32)
-        v = numpy.array(value, ndmin=1, copy=False, dtype=numpy.int32)
-        if v.shape != (self.N,):
-            raise TypeError('Molecules must be a size N array')
-        numpy.copyto(self._molecule, v)
+        if value is not None:
+            if not self.has_molecule():
+                self._molecule = numpy.zeros(self.N, dtype=numpy.int32)
+            v = numpy.array(value, ndmin=1, copy=False, dtype=numpy.int32)
+            if v.shape != (self.N,):
+                raise TypeError('Molecules must be a size N array')
+            numpy.copyto(self._molecule, v)
+        else:
+            self._molecule = None
 
     def has_molecule(self):
         """Check if configuration has molecule tags.
@@ -293,12 +308,15 @@ class Snapshot:
 
     @typeid.setter
     def typeid(self, value):
-        if not self.has_typeid():
-            self._typeid = numpy.ones(self.N, dtype=numpy.int32)
-        v = numpy.array(value, ndmin=1, copy=False, dtype=numpy.int32)
-        if v.shape != (self.N,):
-            raise TypeError('Type must be a size N array')
-        numpy.copyto(self._typeid, v)
+        if value is not None:
+            if not self.has_typeid():
+                self._typeid = numpy.ones(self.N, dtype=numpy.int32)
+            v = numpy.array(value, ndmin=1, copy=False, dtype=numpy.int32)
+            if v.shape != (self.N,):
+                raise TypeError('Type must be a size N array')
+            numpy.copyto(self._typeid, v)
+        else:
+            self._typeid = None
 
     def has_typeid(self):
         """Check if configuration has types.
@@ -320,12 +338,15 @@ class Snapshot:
 
     @charge.setter
     def charge(self, value):
-        if not self.has_charge():
-            self._charge = numpy.zeros(self.N, dtype=numpy.float64)
-        v = numpy.array(value, ndmin=1, copy=False, dtype=numpy.float64)
-        if v.shape != (self.N,):
-            raise TypeError('Charge must be a size N array')
-        numpy.copyto(self._charge, v)
+        if value is not None:
+            if not self.has_charge():
+                self._charge = numpy.zeros(self.N, dtype=numpy.float64)
+            v = numpy.array(value, ndmin=1, copy=False, dtype=numpy.float64)
+            if v.shape != (self.N,):
+                raise TypeError('Charge must be a size N array')
+            numpy.copyto(self._charge, v)
+        else:
+            self._charge = None
 
     def has_charge(self):
         """Check if configuration has charges.
@@ -347,12 +368,15 @@ class Snapshot:
 
     @mass.setter
     def mass(self, value):
-        if not self.has_mass():
-            self._mass = numpy.ones(self.N, dtype=numpy.float64)
-        v = numpy.array(value, ndmin=1, copy=False, dtype=numpy.float64)
-        if v.shape != (self.N,):
-            raise TypeError('Mass must be a size N array')
-        numpy.copyto(self._mass, v)
+        if value is not None:
+            if not self.has_mass():
+                self._mass = numpy.ones(self.N, dtype=numpy.float64)
+            v = numpy.array(value, ndmin=1, copy=False, dtype=numpy.float64)
+            if v.shape != (self.N,):
+                raise TypeError('Mass must be a size N array')
+            numpy.copyto(self._mass, v)
+        else:
+            self._mass = None
 
     def has_mass(self):
         """Check if configuration has masses.

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,3 +1,5 @@
+import copy
+
 import numpy
 import pytest
 
@@ -79,4 +81,41 @@ def test_charge(snap):
     assert numpy.allclose(snap.charge, charge)
     with pytest.raises(TypeError):
         snap.typeid = [0,0]
-    
+
+def test_copy(snap):
+    snap.id = [2, 0, 1]
+    snap.position = [[0.1,0.2,0.3],[-0.4,-0.5,-0.6],[0.7,0.8,0.9]]
+    snap.image = [[1,2,3],[-4,-5,-6],[7,8,9]]
+    snap.velocity = [[-3,-2,-1],[6,5,4],[9,8,7]]
+    snap.typeid = [2,1,2]
+    snap.mass = [3,2,3]
+    snap.molecule = [2,0,1]
+    snap.charge = [-1,0,1]
+
+    # check shallow copy works
+    snap_shallow = copy.copy(snap)
+    assert numpy.all(snap_shallow.id == snap.id)
+    assert numpy.allclose(snap_shallow.position, snap.position)
+    assert numpy.all(snap_shallow.image == snap.image)
+    assert numpy.allclose(snap_shallow.velocity, snap.velocity)
+    assert numpy.all(snap_shallow.typeid == snap.typeid)
+    assert numpy.allclose(snap_shallow.mass, snap.mass)
+    assert numpy.all(snap_shallow.molecule == snap.molecule)
+    assert numpy.allclose(snap_shallow.charge, snap.charge)
+
+    # check deep copy works
+    snap_deep = copy.deepcopy(snap)
+    assert numpy.all(snap_deep.id == snap.id)
+    assert numpy.allclose(snap_deep.position, snap.position)
+    assert numpy.all(snap_deep.image == snap.image)
+    assert numpy.allclose(snap_deep.velocity, snap.velocity)
+    assert numpy.all(snap_deep.typeid == snap.typeid)
+    assert numpy.allclose(snap_deep.mass, snap.mass)
+    assert numpy.all(snap_deep.molecule == snap.molecule)
+    assert numpy.allclose(snap_deep.charge, snap.charge)
+
+    # change the original snapshot and check shallow changes, but deep does not
+    old_ids = list(snap.id)
+    snap.id = [3, 4, 5]
+    assert numpy.all(snap_shallow.id == snap.id)
+    assert numpy.all(snap_deep.id == old_ids)


### PR DESCRIPTION
This PR adds a `copy_from` argument to the `DumpFile` so that it can use a `Snapshot` (e.g., read from a `DataFile`) to copy certain static fields.