### PR TITLE
Read schema from dump files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Dump file defaults to reading schema from atoms header.
+
 ### Fixed
 - Dump file now reads/writes box bounds header correctly.
 

--- a/tests/test_dump_file.py
+++ b/tests/test_dump_file.py
@@ -21,12 +21,12 @@ def test_dump_file_min(snap, use_gzip, shuffle_ids, sort_ids, tmp_path):
         filename = tmp_path / "atoms.lammpstrj"
     schema = {'id': 0, 'position': (1, 2, 3)}
     f = lammpsio.DumpFile.create(filename, schema, snaps)
-    f.sort_ids = sort_ids
     assert filename.exists
     assert len(f) == 2
 
     # read it back in and check snapshots
-    read_snaps = [s for s in f]
+    f2 = lammpsio.DumpFile(filename, sort_ids=sort_ids)
+    read_snaps = [s for s in f2]
     for i in range(2):
         assert read_snaps[i].N == snaps[i].N
         assert read_snaps[i].step == snaps[i].step
@@ -101,12 +101,12 @@ def test_dump_file_all(snap, use_gzip, shuffle_ids, sort_ids, tmp_path):
     else:
         filename = tmp_path / "atoms.lammpstrj"
     f = lammpsio.DumpFile.create(filename, schema, snaps)
-    f.sort_ids = sort_ids
     assert filename.exists
     assert len(f) == 2
 
     # read it back in and check snapshots
-    read_snaps = [s for s in f]
+    f2 = lammpsio.DumpFile(filename, sort_ids=sort_ids)
+    read_snaps = [s for s in f2]
     for i,s in enumerate(f):
         assert read_snaps[i].N == snaps[i].N
         assert read_snaps[i].step == snaps[i].step


### PR DESCRIPTION
This PR supports reading schemas automatically from the dump file. The LAMMPS keys are converted to lammpsio attributes as needed for reading/writing. A schema can still be specified, e.g., in case someone did not write it or there is a mistake in it.