### PR TITLE
Support interconversion with HOOMD GSD format

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 numpy
+packaging

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ include_package_data = True
 python_requires = >=3.8
 install_requires =
     numpy
+    packaging
 
 [options.packages.find]
 where = src

--- a/src/lammpsio/__init__.py
+++ b/src/lammpsio/__init__.py
@@ -1,27 +1,9 @@
 import gzip
 import os
 import pathlib
+import warnings
 
 import numpy
-from packaging import version
-
-try:
-    import gsd
-    import gsd.hoomd
-
-    _gsd_found = True
-    _gsd_version = version.Version(gsd.__version__)
-    if _gsd_version.major >= 3:
-        _GSDFrame = gsd.hoomd.Frame
-        _gsd_valid_types = (gsd.hoomd.Frame,)
-    elif _gsd_version >= version.Version("2.8.0"):
-        _GSDFrame = gsd.hoomd.Frame
-        _gsd_valid_types = (gsd.hoomd.Frame, gsd.hoomd.Snapshot)
-    else:
-        _GSDFrame = gsd.hoomd.Snapshot
-        _gsd_valid_types = (gsd.hoomd.Snapshot,)
-except ImportError:
-    _gsd_found = False
 
 
 def _readline(file_, require=False):
@@ -164,38 +146,37 @@ class Snapshot:
         self._mass = None
 
     @classmethod
-    def cast(cls, value):
-        """Cast a snapshot-like object.
+    def from_hoomd_gsd(cls, frame):
+        """Create from a HOOMD GSD frame.
 
         Parameters
         ----------
         value : :class:`gsd.hoomd.Frame` or `gsd.hoomd.Snapshot`
-            Snapshot-like value to cast. Only HOOMD GSD types are currently
-            supported.
+            HOOMD GSD frame to convert.
 
         """
-        if _gsd_found and isinstance(value, _gsd_valid_types):
-            # process HOOMD box to LAMMPS box
-            L = numpy.asarray(value.configuration.box[:3], dtype=float)
-            tilt = numpy.asarray(value.configuration.box[3:], dtype=float)
-            tilt[0] *= L[1]
-            tilt[1:] *= L[2]
-            box = Box.cast(numpy.concatenate((-0.5 * L, 0.5 * L, tilt)))
+        # process HOOMD box to LAMMPS box
+        L = numpy.asarray(frame.configuration.box[:3], dtype=float)
+        tilt = numpy.asarray(frame.configuration.box[3:], dtype=float)
+        tilt[0] *= L[1]
+        tilt[1:] *= L[2]
+        box = Box(low=-0.5 * L, high=0.5 * L, tilt=tilt)
 
-            snap = Snapshot(
-                N=value.particles.N,
-                box=box,
-                step=value.configuration.step,
-            )
+        snap = Snapshot(
+            N=frame.particles.N,
+            box=box,
+            step=frame.configuration.step,
+        )
+        snap.position = frame.particles.position
+        snap.velocity = frame.particles.velocity
+        snap.image = frame.particles.image
+        snap.typeid = numpy.asarray(frame.particles.typeid, dtype=int) + 1
+        snap.charge = frame.particles.charge
+        snap.mass = frame.particles.mass
 
-            snap.position = value.particles.position
-            snap.velocity = value.particles.velocity
-            snap.image = value.particles.image
-            snap.typeid = numpy.asarray(value.particles.typeid, dtype=int) + 1
-            snap.charge = value.particles.charge
-            snap.mass = value.particles.mass
-        else:
-            raise TypeError("Cannot cast snapshot, type unknown")
+        snap.molecule = numpy.asarray(frame.particles.body, dtype=int) + 1
+        if numpy.any(snap.molecule < 0):
+            warnings.warn("Some molecule IDs are negative, remapping needed.")
 
         return snap
 

--- a/src/lammpsio/__init__.py
+++ b/src/lammpsio/__init__.py
@@ -4,6 +4,16 @@ import pathlib
 import warnings
 
 import numpy
+from packaging import version
+
+_optional_imports = set()
+try:
+    import gsd
+    import gsd.hoomd
+
+    _optional_imports.add("gsd")
+except ImportError:
+    pass
 
 
 def _readline(file_, require=False):
@@ -151,15 +161,31 @@ class Snapshot:
 
         Parameters
         ----------
-        value : :class:`gsd.hoomd.Frame` or `gsd.hoomd.Snapshot`
+        frame : :class:`gsd.hoomd.Frame` or `gsd.hoomd.Snapshot`
             HOOMD GSD frame to convert.
 
+        Returns
+        -------
+        :class:`Snapshot`
+            Snapshot created from HOOMD GSD frame.
+        dict
+            A map from the :attr:`Snapshot.typeid` to the HOOMD type.
+
         """
+        # ensures frame is well formed and that we have NumPy arrays
+        frame.validate()
+
         # process HOOMD box to LAMMPS box
-        L = numpy.asarray(frame.configuration.box[:3], dtype=float)
-        tilt = numpy.asarray(frame.configuration.box[3:], dtype=float)
-        tilt[0] *= L[1]
-        tilt[1:] *= L[2]
+        L = frame.configuration.box[:3]
+        tilt = frame.configuration.box[3:]
+        if frame.configuration.dimensions == 3:
+            tilt[0] *= L[1]
+            tilt[1:] *= L[2]
+        elif frame.configuration.dimensions == 2:
+            tilt[0] *= L[1]
+            # HOOMD boxes can have Lz = 0, but LAMMPS does not allow this.
+            if L[2] == 0:
+                L[2] = 1.0
         box = Box(low=-0.5 * L, high=0.5 * L, tilt=tilt)
 
         snap = Snapshot(
@@ -170,15 +196,98 @@ class Snapshot:
         snap.position = frame.particles.position
         snap.velocity = frame.particles.velocity
         snap.image = frame.particles.image
-        snap.typeid = numpy.asarray(frame.particles.typeid, dtype=int) + 1
+        snap.typeid = frame.particles.typeid + 1
         snap.charge = frame.particles.charge
         snap.mass = frame.particles.mass
 
-        snap.molecule = numpy.asarray(frame.particles.body, dtype=int) + 1
+        snap.molecule = frame.particles.body + 1
         if numpy.any(snap.molecule < 0):
             warnings.warn("Some molecule IDs are negative, remapping needed.")
 
-        return snap
+        type_map = {typeid + 1: i for typeid, i in enumerate(frame.particles.types)}
+
+        return snap, type_map
+
+    def to_hoomd_gsd(self, type_map=None):
+        """Create a HOOMD GSD frame.
+
+        Parameters
+        ----------
+        type_map : dict
+            A map from the :attr:`Snapshot.typeid` to a HOOMD type.
+            If not specified, the typeids are used as the types.
+
+        Returns
+        -------
+        :class:`gsd.hoomd.Frame` or :class:`gsd.hoomd.Snapshot`
+            Converted HOOMD GSD frame.
+
+        """
+        if "gsd" not in _optional_imports:
+            raise ImportError("GSD package not found")
+
+        # make Frame/Snapshot without deprecation warnings
+        if version.Version(gsd.__version__) >= version.Version("2.8.0"):
+            frame = gsd.hoomd.Frame()
+        else:
+            frame = gsd.hoomd.Snapshot()
+
+        if self.step is not None:
+            frame.configuration.step = int(self.step)
+
+        # we could shift the box later, but for now this is an error
+        if not numpy.allclose(-self.box.low, self.box.high):
+            raise ValueError("GSD boxes must be centered around 0")
+        L = self.box.high - self.box.low
+        if self.box.tilt is not None:
+            tilt = self.box.tilt
+        else:
+            tilt = [0, 0, 0]
+        frame.configuration.box = numpy.concatenate((L, tilt))
+
+        # sort tags if specified and not increasing because GSD guarantees an order
+        reverse_order = None
+        if self.has_id() and self.N > 1 and not numpy.all(self.id[1:] > self.id[:-1]):
+            order = numpy.argsort(self.id)
+            self.reorder(order, check_order=False)
+            # build the reverse map to undo the sort later
+            reverse_order = numpy.zeros(self.N, dtype=int)
+            for i, v in enumerate(order):
+                reverse_order[v] = i
+
+        frame.particles.N = self.N
+        if self.has_position():
+            frame.particles.position = self.position.copy()
+        if self.has_velocity():
+            frame.particles.velocity = self.velocity.copy()
+        if self.has_image():
+            frame.particles.image = self.image.copy()
+        if self.has_typeid():
+            frame.particles.typeid = numpy.zeros(self.N, dtype=int)
+            if type_map is None:
+                sorted_typeids = numpy.sort(numpy.unique(self.typeid))
+                frame.particles.types = [str(typeid) for typeid in sorted_typeids]
+                for typeidx, typeid in enumerate(sorted_typeids):
+                    frame.particles.typeid[self.typeid == typeid] = typeidx
+            else:
+                frame.particles.types = list(type_map.values())
+                reverse_type_map = {
+                    typeid: typeidx for typeidx, typeid in enumerate(type_map.keys())
+                }
+                for i, typeid in enumerate(self.typeid):
+                    frame.particles.typeid[i] = reverse_type_map[typeid]
+        if self.has_charge():
+            frame.particles.charge = self.charge.copy()
+        if self.has_mass():
+            frame.particles.mass = self.mass.copy()
+        if self.has_molecule():
+            frame.particles.body = self.molecule - 1
+
+        # undo the sort so object goes back the way it was
+        if reverse_order is not None:
+            self.reorder(reverse_order, check_order=False)
+
+        return frame
 
     @property
     def N(self):

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
-pytest==7.1.3
-pytest-lazy-fixture==0.6.3
+gsd
+pytest
+pytest-lazy-fixture

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -25,8 +25,9 @@ def test_cast_gsd():
     gsd_snap.particles.typeid = [1, 0]
     gsd_snap.particles.mass = [3, 2]
     gsd_snap.particles.charge = [-1, 1]
+    gsd_snap.particles.body = [0, -1]
 
-    snap = lammpsio.Snapshot.cast(gsd_snap)
+    snap = lammpsio.Snapshot.from_hoomd_gsd(gsd_snap)
     assert snap.step == 3
 
     assert numpy.allclose(snap.box.low, [-2, -2.5, -3])
@@ -37,9 +38,15 @@ def test_cast_gsd():
     assert numpy.all(snap.position == [[0.1, 0.2, 0.3], [-0.1, -0.2, -0.3]])
     assert numpy.all(snap.image == [[1, -1, 0], [0, 2, -2]])
     assert numpy.all(snap.velocity == [[1, 2, 3], [-4, -5, -6]])
+    assert numpy.all(snap.molecule == [1, 0])
     assert numpy.all(snap.typeid == [2, 1])
     assert numpy.all(snap.mass == [3, 2])
     assert numpy.all(snap.charge == [-1, 1])
+
+    # check for warning on floppy molecules
+    gsd_snap.particles.body = [-2, -1]
+    with pytest.warns():
+        lammpsio.Snapshot.from_hoomd_gsd(gsd_snap)
 
 
 def test_position(snap):

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,8 +1,10 @@
 import copy
 
+import gsd
 import gsd.hoomd
 import numpy
 import pytest
+from packaging import version
 
 import lammpsio
 
@@ -13,40 +15,76 @@ def test_create(snap):
     assert snap.step == 10
 
 
-def test_cast_gsd():
-    gsd_snap = gsd.hoomd.Frame()
-    gsd_snap.configuration.step = 3
-    gsd_snap.configuration.box = [4, 5, 6, 0.1, 0.2, 0.3]
-    gsd_snap.particles.N = 2
-    gsd_snap.particles.position = [[0.1, 0.2, 0.3], [-0.1, -0.2, -0.3]]
-    gsd_snap.particles.image = [[1, -1, 0], [0, 2, -2]]
-    gsd_snap.particles.velocity = [[1, 2, 3], [-4, -5, -6]]
-    gsd_snap.particles.types = ["A", "B"]
-    gsd_snap.particles.typeid = [1, 0]
-    gsd_snap.particles.mass = [3, 2]
-    gsd_snap.particles.charge = [-1, 1]
-    gsd_snap.particles.body = [0, -1]
+def test_gsd_conversion():
+    # make a GSD frame
+    if version.Version(gsd.__version__) >= version.Version("2.8.0"):
+        frame = gsd.hoomd.Frame()
+    else:
+        frame = gsd.hoomd.Snapshot()
+    frame.configuration.step = 3
+    frame.configuration.box = [4, 5, 6, 0.1, 0.2, 0.3]
+    frame.particles.N = 2
+    frame.particles.position = [[0.1, 0.2, 0.3], [-0.1, -0.2, -0.3]]
+    frame.particles.image = [[1, -1, 0], [0, 2, -2]]
+    frame.particles.velocity = [[1, 2, 3], [-4, -5, -6]]
+    frame.particles.body = [0, -1]
+    frame.particles.types = ["A", "B"]
+    frame.particles.typeid = [1, 0]
+    frame.particles.mass = [3, 2]
+    frame.particles.charge = [-1, 1]
 
-    snap = lammpsio.Snapshot.from_hoomd_gsd(gsd_snap)
+    # make Snapshot from GSD
+    snap, type_map = lammpsio.Snapshot.from_hoomd_gsd(frame)
     assert snap.step == 3
-
     assert numpy.allclose(snap.box.low, [-2, -2.5, -3])
     assert numpy.allclose(snap.box.high, [2, 2.5, 3])
     assert numpy.allclose(snap.box.tilt, [0.5, 1.2, 1.8])
-
     assert snap.N == 2
-    assert numpy.all(snap.position == [[0.1, 0.2, 0.3], [-0.1, -0.2, -0.3]])
+    assert numpy.allclose(snap.position, [[0.1, 0.2, 0.3], [-0.1, -0.2, -0.3]])
     assert numpy.all(snap.image == [[1, -1, 0], [0, 2, -2]])
-    assert numpy.all(snap.velocity == [[1, 2, 3], [-4, -5, -6]])
+    assert numpy.allclose(snap.velocity, [[1, 2, 3], [-4, -5, -6]])
     assert numpy.all(snap.molecule == [1, 0])
     assert numpy.all(snap.typeid == [2, 1])
-    assert numpy.all(snap.mass == [3, 2])
-    assert numpy.all(snap.charge == [-1, 1])
+    assert numpy.allclose(snap.mass, [3, 2])
+    assert numpy.allclose(snap.charge, [-1, 1])
+    assert type_map == {1: "A", 2: "B"}
+
+    # go back to GSD frame
+    frame2 = snap.to_hoomd_gsd(type_map)
+    assert frame2.configuration.step == frame.configuration.step
+    assert numpy.allclose(frame2.configuration.box, frame.configuration.box)
+    assert frame2.particles.N == frame.particles.N
+    assert numpy.allclose(frame2.particles.position, frame.particles.position)
+    assert numpy.all(frame2.particles.image == frame.particles.image)
+    assert numpy.allclose(frame2.particles.velocity, frame.particles.velocity)
+    assert numpy.all(frame2.particles.types == frame.particles.types)
+    assert numpy.all(frame2.particles.typeid == frame.particles.typeid)
+    assert numpy.allclose(frame2.particles.mass, frame.particles.mass)
+    assert numpy.allclose(frame2.particles.charge, frame.particles.charge)
+    assert numpy.all(frame2.particles.body == frame.particles.body)
+
+    # do the same thing, but lose the type map
+    frame3 = snap.to_hoomd_gsd()
+    assert numpy.all(frame3.particles.types == ["1", "2"])
+    assert numpy.all(frame3.particles.typeid == [1, 0])
 
     # check for warning on floppy molecules
-    gsd_snap.particles.body = [-2, -1]
+    frame.particles.body = [-2, -1]
     with pytest.warns():
-        lammpsio.Snapshot.from_hoomd_gsd(gsd_snap)
+        lammpsio.Snapshot.from_hoomd_gsd(frame)
+
+    # check for barebones Snapshot going to GSD
+    snap2 = lammpsio.Snapshot(N=2, box=lammpsio.Box([-5, -5, -5], [5, 5, 5]))
+    snap2.to_hoomd_gsd()
+    # check again with id remapping to make sure order is preserved
+    snap2.id = [2, 1]
+    snap2.to_hoomd_gsd()
+    assert numpy.all(snap2.id == [2, 1])
+
+    # check for error out on bad box
+    snap2.box.low = [-10, -10, -10]
+    with pytest.raises(ValueError):
+        snap2.to_hoomd_gsd()
 
 
 def test_position(snap):


### PR DESCRIPTION
* Adds a `from_hoomd_gsd` method to `Snapshot` to convert from a GSD HOOMD frame.
* Adds a `to_hoomd_gsd` method to `Snapshot` to convert to a GSD HOOMD frame.

Fixes #13 