### PR TITLE
Fix compatibility with GSD 3

### DIFF
--- a/src/lammpsio/snapshot.py
+++ b/src/lammpsio/snapshot.py
@@ -121,8 +121,11 @@ class Snapshot:
             raise ImportError("GSD package not found")
 
         # make Frame/Snapshot without deprecation warnings
-        gsd_version = packaging.version.Version(gsd.__version__)
-        if gsd_version >= packaging.version.Version("2.8.0"):
+        try:
+            gsd_version = gsd.version.version
+        except AttributeError:
+            gsd_version = gsd.__version__
+        if packaging.version.Version(gsd_version) >= packaging.version.Version("2.8.0"):
             frame = gsd.hoomd.Frame()
         else:
             frame = gsd.hoomd.Snapshot()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -17,7 +17,11 @@ def test_create(snap):
 
 def test_gsd_conversion():
     # make a GSD frame
-    if version.Version(gsd.__version__) >= version.Version("2.8.0"):
+    try:
+        gsd_version = gsd.version.version
+    except AttributeError:
+        gsd_version = gsd.__version__
+    if version.Version(gsd_version) >= version.Version("2.8.0"):
         frame = gsd.hoomd.Frame()
     else:
         frame = gsd.hoomd.Snapshot()


### PR DESCRIPTION
The way to check the version number has changed, so we need something backward compatible.