### PR TITLE
Fix image validation of dump schema

### DIFF
--- a/src/lammpsio/dump.py
+++ b/src/lammpsio/dump.py
@@ -323,7 +323,7 @@ class DumpFile:
                                 else:
                                     schema[key] = i
                         # validate tuple
-                        for key in ("position", "velocity", " image"):
+                        for key in ("position", "velocity", "image"):
                             if key in schema and any(x is None for x in schema[key]):
                                 raise IOError("lammpsio requires 3-element vectors")
                         self.schema = schema

--- a/tests/test_dump_file.py
+++ b/tests/test_dump_file.py
@@ -218,8 +218,8 @@ def test_faulty_dump_schema(snap, tmp_path, schema):
         f"1 1 {schema_zeros}\n"
     )
     f.close()
-    filename = tmp_path / "atoms.lammpstrj"
 
+    filename = tmp_path / "atoms.lammpstrj"
     traj = lammpsio.DumpFile(filename)
     with pytest.raises(IOError):
         for snap in traj:

--- a/tests/test_dump_file.py
+++ b/tests/test_dump_file.py
@@ -190,21 +190,68 @@ def test_copy_from(snap, tmp_path):
 
 
 def test_faulty_dump_schema(snap, tmp_path):
+    # test image schema
     f = open(tmp_path / "atoms.lammpstrj", "w")
     f.write(
-        """ITEM: TIMESTEP
-            0
-            ITEM: NUMBER OF ATOMS
-            1
-            ITEM: BOX BOUNDS pp pp pp
-            -7.0 7.0
-            -7.0 7.0
-            -7.0 7.0
-            ITEM: ATOMS id type ix iy
-            1 1 0 0"""
+        """
+    ITEM: TIMESTEP
+    0
+    ITEM: NUMBER OF ATOMS
+    1
+    ITEM: BOX BOUNDS pp pp pp
+    -7.0 7.0
+    -7.0 7.0
+    -7.0 7.0
+    ITEM: ATOMS id type ix iy
+    1 1 0 0 """
     )
     f.close()
     filename = tmp_path / "atoms.lammpstrj"
     with pytest.raises(OSError) as error:
         pytest.raises(lammpsio.DumpFile(filename))
+
+    assert str(error.value) == "lammpsio requires 3-element vectors"
+
+    # test position schema
+    f = open(tmp_path / "atoms.lammpstrj", "w")
+    f.write(
+        """
+    ITEM: TIMESTEP
+    0
+    ITEM: NUMBER OF ATOMS
+    1
+    ITEM: BOX BOUNDS pp pp pp
+    -7.0 7.0
+    -7.0 7.0
+    -7.0 7.0
+    ITEM: ATOMS id type x y
+    1 1 0 0 """
+    )
+    f.close()
+    filename = tmp_path / "atoms.lammpstrj"
+    with pytest.raises(OSError) as error:
+        pytest.raises(lammpsio.DumpFile(filename))
+
+    assert str(error.value) == "lammpsio requires 3-element vectors"
+
+    # test velocity schema
+    f = open(tmp_path / "atoms.lammpstrj", "w")
+    f.write(
+        """
+    ITEM: TIMESTEP
+    0
+    ITEM: NUMBER OF ATOMS
+    1
+    ITEM: BOX BOUNDS pp pp pp
+    -7.0 7.0
+    -7.0 7.0
+    -7.0 7.0
+    ITEM: ATOMS id type vx vy
+    1 1 0 0"""
+    )
+    f.close()
+    filename = tmp_path / "atoms.lammpstrj"
+    with pytest.raises(OSError) as error:
+        pytest.raises(lammpsio.DumpFile(filename))
+
     assert str(error.value) == "lammpsio requires 3-element vectors"

--- a/tests/test_dump_file.py
+++ b/tests/test_dump_file.py
@@ -190,19 +190,17 @@ def test_copy_from(snap, tmp_path):
 
 
 def test_faulty_dump_schema(snap, tmp_path):
-    f = open(tmp_path / "atoms.lammpstrj", "r")
-    f.write(
-        """ITEM: TIMESTEP \n
-            0 \n
-            ITEM: NUMBER OF ATOMS \n
-            1 \n
-            ITEM: BOX BOUNDS pp pp pp \n
-            -7.0 7.0 \n
-            -7.0 7.0 \n
-            -7.0 7.0 \n
-            ITEM: ATOMS id type ix iy \n
-            1 1 0 0"""
-    )
+    f = open(tmp_path / "atoms.lammpstrj", "w")
+    f.write("""ITEM: TIMESTEP
+            0
+            ITEM: NUMBER OF ATOMS
+            1
+            ITEM: BOX BOUNDS pp pp pp
+            -7.0 7.0
+            -7.0 7.0
+            -7.0 7.0
+            ITEM: ATOMS id type ix iy
+            1 1 0 0""")
     f.close()
     filename = tmp_path / "atoms.lammpstrj"
     with pytest.raises(OSError) as error:

--- a/tests/test_dump_file.py
+++ b/tests/test_dump_file.py
@@ -203,23 +203,24 @@ def test_copy_from(snap, tmp_path):
 )
 def test_faulty_dump_schema(snap, tmp_path, schema):
     # test schema
-    schema_zeros = [0] * len(schema.split())
-    print(schema_zeros)
-    f = open(tmp_path/"atoms.lammpstrj", "w")
+    schema_zeros = " ".join(["0"] * len(schema.split()))
+    f = open(tmp_path / "atoms.lammpstrj", "w")
     f.write(
         "ITEM: TIMESTEP\n"
-        "0 \n"
-        "ITEM: NUMBER OF ATOMS \n"
-        "1 \n"
+        "0\n"
+        "ITEM: NUMBER OF ATOMS\n"
+        "1\n"
         "ITEM: BOX BOUNDS pp pp pp\n"
-        "-7.0 7.0 \n"
-        "-7.0 7.0 \n"
-        "-7.0 7.0 \n"
+        "-7.0 7.0\n"
+        "-7.0 7.0\n"
+        "-7.0 7.0\n"
         f"ITEM: ATOMS id type {schema}\n"
-        f"1 1 {" ".join(str(i) for i in schema_zeros)} \n"
+        f"1 1 {schema_zeros}\n"
     )
     f.close()
-    filename = tmp_path/"atoms.lammpstrj"
+    filename = tmp_path / "atoms.lammpstrj"
 
+    traj = lammpsio.DumpFile(filename)
     with pytest.raises(IOError):
-        lammpsio.DumpFile(filename)
+        for snap in traj:
+            pass

--- a/tests/test_dump_file.py
+++ b/tests/test_dump_file.py
@@ -191,7 +191,8 @@ def test_copy_from(snap, tmp_path):
 
 def test_faulty_dump_schema(snap, tmp_path):
     f = open(tmp_path / "atoms.lammpstrj", "w")
-    f.write("""ITEM: TIMESTEP
+    f.write(
+        """ITEM: TIMESTEP
             0
             ITEM: NUMBER OF ATOMS
             1
@@ -200,7 +201,8 @@ def test_faulty_dump_schema(snap, tmp_path):
             -7.0 7.0
             -7.0 7.0
             ITEM: ATOMS id type ix iy
-            1 1 0 0""")
+            1 1 0 0"""
+    )
     f.close()
     filename = tmp_path / "atoms.lammpstrj"
     with pytest.raises(OSError) as error:

--- a/tests/test_dump_file.py
+++ b/tests/test_dump_file.py
@@ -191,16 +191,18 @@ def test_copy_from(snap, tmp_path):
 
 def test_faulty_dump_schema(snap, tmp_path):
     f = open(tmp_path / "atoms.lammpstrj", "r")
-    f.write("""ITEM: TIMESTEP \n 
-            0 \n 
-            ITEM: NUMBER OF ATOMS \n 
-            1 \n 
-            ITEM: BOX BOUNDS pp pp pp \n 
-            -7.0 7.0 \n 
-            -7.0 7.0 \n 
-            -7.0 7.0 \n 
+    f.write(
+        """ITEM: TIMESTEP \n
+            0 \n
+            ITEM: NUMBER OF ATOMS \n
+            1 \n
+            ITEM: BOX BOUNDS pp pp pp \n
+            -7.0 7.0 \n
+            -7.0 7.0 \n
+            -7.0 7.0 \n
             ITEM: ATOMS id type ix iy \n
-            1 1 0 0""")
+            1 1 0 0"""
+    )
     f.close()
     filename = tmp_path / "atoms.lammpstrj"
     with pytest.raises(OSError) as error:

--- a/tests/test_dump_file.py
+++ b/tests/test_dump_file.py
@@ -189,24 +189,20 @@ def test_copy_from(snap, tmp_path):
     assert numpy.allclose(read_snap.charge, [0, 1, -1])
 
 
-def test_dump_schema_error(snap, tmp_path):
-    filename = tmp_path / "atoms.lammpstrj"
-    schema = {"id": 0, "image": ([1, 2, 3])}
-    lammpsio.DumpFile.create(filename, schema, snap)
+def test_faulty_dump_schema(snap, tmp_path):
     f = open(tmp_path / "atoms.lammpstrj", "r")
-    g = open(tmp_path / "atoms_validate.lammpstrj", "w")
-    count = 0
-    for line in f:
-        if count < 8:
-            if line.strip():
-                g.write(" ".join(line.split()) + "\n")
-        else:
-            if line.strip():
-                g.write(" ".join(line.split()[:-1]) + "\n")
-        count += 1
+    f.write("""ITEM: TIMESTEP \n 
+            0 \n 
+            ITEM: NUMBER OF ATOMS \n 
+            1 \n 
+            ITEM: BOX BOUNDS pp pp pp \n 
+            -7.0 7.0 \n 
+            -7.0 7.0 \n 
+            -7.0 7.0 \n 
+            ITEM: ATOMS id type ix iy \n
+            1 1 0 0""")
     f.close()
-    g.close()
-    filename = tmp_path / "atoms_validate.lammpstrj"
+    filename = tmp_path / "atoms.lammpstrj"
     with pytest.raises(OSError) as error:
         pytest.raises(lammpsio.DumpFile(filename))
     assert str(error.value) == "lammpsio requires 3-element vectors"

--- a/tests/test_dump_file.py
+++ b/tests/test_dump_file.py
@@ -223,4 +223,3 @@ def test_faulty_dump_schema(snap, tmp_path, schema):
 
     with pytest.raises(IOError):
         lammpsio.DumpFile(filename)
-

--- a/tests/test_dump_file.py
+++ b/tests/test_dump_file.py
@@ -201,7 +201,7 @@ def test_copy_from(snap, tmp_path):
         "image-2d",
     ],
 )
-def test_faulty_dump_schema(snap, tmp_path, schema):
+def test_faulty_dump_schema(tmp_path, schema):
     # test schema
     schema_zeros = " ".join(["0"] * len(schema.split()))
     filename = tmp_path / "atoms.lammpstrj"

--- a/tests/test_dump_file.py
+++ b/tests/test_dump_file.py
@@ -219,7 +219,7 @@ def test_faulty_dump_schema(snap, tmp_path, schema):
         f"1 1 {schema_zeros}\n"
     )
     f.close()
-    
+
     traj = lammpsio.DumpFile(filename)
     with pytest.raises(IOError):
         for snap in traj:

--- a/tests/test_dump_file.py
+++ b/tests/test_dump_file.py
@@ -204,7 +204,8 @@ def test_copy_from(snap, tmp_path):
 def test_faulty_dump_schema(snap, tmp_path, schema):
     # test schema
     schema_zeros = " ".join(["0"] * len(schema.split()))
-    f = open(tmp_path / "atoms.lammpstrj", "w")
+    filename = tmp_path / "atoms.lammpstrj"
+    f = open(filename, "w")
     f.write(
         "ITEM: TIMESTEP\n"
         "0\n"
@@ -218,8 +219,7 @@ def test_faulty_dump_schema(snap, tmp_path, schema):
         f"1 1 {schema_zeros}\n"
     )
     f.close()
-
-    filename = tmp_path / "atoms.lammpstrj"
+    
     traj = lammpsio.DumpFile(filename)
     with pytest.raises(IOError):
         for snap in traj:


### PR DESCRIPTION
Fix typo validating the image vector in the dump schema. Add unit tests for faulty dump file schemas.

Fixes #42 