### PR TITLE
Add wrapping and scaling methods to class Box

### DIFF
--- a/src/lammpsio/box.py
+++ b/src/lammpsio/box.py
@@ -96,3 +96,31 @@ class Box:
             if v.shape != (3,):
                 raise TypeError("Tilt must be a 3-tuple")
         self._tilt = v
+
+    @property
+    def _vectors(self):
+        v = numpy.diag(self.high - self.low)
+        if self.tilt is not None:
+            v[1, 0] = self.tilt[0]
+            v[2, :2] = self.tilt[1:]
+        return v
+
+    def unscale(self, scaled_position):
+        return scaled_position @ self._vectors + self.low
+
+    def scale(self, position):
+        return (position - self.low) @ numpy.linalg.inv(self._vectors)
+
+    def unwrap_scaled(self, scaled_position, image):
+        return scaled_position + image
+
+    def wrap_scaled(self, scaled_position):
+        image = numpy.floor(scaled_position)
+        return scaled_position - image, image
+
+    def unwrap(self, position, image):
+        return position + image @ self._vectors
+
+    def wrap(self, position):
+        position_wrapped_scaled, image = self.wrap_scaled(self.scale(position))
+        return self.unscale(position_wrapped_scaled), image


### PR DESCRIPTION
See #11 

This adds methods for converting wrapped/unwrapped and scaled/real coordinates.

I also have a (rudimentary) implementation for reading dumps with scaled and/or unwrapped coordinates at https://github.com/PhilLecl/lammpsio/tree/read-dump-su.
I've used it together with the dumps generated by the input script below to test the calculations.
Note that unwrapping can cause the floating point error to become rather large. 

---

```
# randomly generated periodic triclinic simulation box
units real
region r1 prism -87 9 -80 58 -63 83 9 -13 5
boundary p p p
create_box 1 r1
mass * 1

# some random atoms with random velocities
create_atoms 1 random 100 20240519 NULL
velocity all create 298.15 20240519
fix thermostat all nvt temp 298.15 298.15 100.0

# dumps
dump d1 all custom 1000 dump.position_i id x y z ix iy iz
dump d2 all custom 1000 dump.position_u id xu yu zu
dump d3 all custom 1000 dump.position_si id xs ys zs ix iy iz
dump d4 all custom 1000 dump.position_su id xsu ysu zsu

# run
run 100000
```