### PR TITLE
Make lammpsio compatible with NumPy 2

### DIFF
--- a/src/lammpsio/_compatibility.py
+++ b/src/lammpsio/_compatibility.py
@@ -1,0 +1,27 @@
+import numpy
+import packaging.version
+
+try:
+    import gsd
+
+    try:
+        gsd_version = gsd.version.version
+    except AttributeError:
+        gsd_version = gsd.__version__
+    gsd_version = packaging.version.Version(gsd_version)
+except ModuleNotFoundError:
+    gsd_version = None
+
+try:
+    import pyzstd
+
+    pyzstd_version = packaging.version.Version(pyzstd.__version__)
+except ModuleNotFoundError:
+    pyzstd_version = None
+
+# https://github.com/scipy/scipy/pull/20172
+numpy_version = packaging.version.Version(numpy.__version__)
+if numpy_version >= packaging.version.Version("2.0.0"):
+    numpy_copy_if_needed = None
+else:
+    numpy_copy_if_needed = False

--- a/src/lammpsio/_compatibility.py
+++ b/src/lammpsio/_compatibility.py
@@ -1,17 +1,27 @@
 import numpy
 import packaging.version
 
+# GSD - optional import
 try:
     import gsd
+    import gsd.hoomd
 
+    # determine how GSD stores its version
     try:
         gsd_version = gsd.version.version
     except AttributeError:
         gsd_version = gsd.__version__
     gsd_version = packaging.version.Version(gsd_version)
+
+    # GSD >= 2.8.0 deprecated Snapshot in favor of Frame
+    if gsd_version >= packaging.version.Version("2.8.0"):
+        gsd_frame_class = gsd.hoomd.Frame
+    else:
+        gsd_frame_class = gsd.hoomd.Snapshot
 except ModuleNotFoundError:
     gsd_version = None
 
+# pyzstd - optional import
 try:
     import pyzstd
 
@@ -19,7 +29,8 @@ try:
 except ModuleNotFoundError:
     pyzstd_version = None
 
-# https://github.com/scipy/scipy/pull/20172
+# numpy
+# copy behavior changed in 2.0.0, see https://github.com/scipy/scipy/pull/20172
 numpy_version = packaging.version.Version(numpy.__version__)
 if numpy_version >= packaging.version.Version("2.0.0"):
     numpy_copy_if_needed = None

--- a/src/lammpsio/box.py
+++ b/src/lammpsio/box.py
@@ -1,5 +1,7 @@
 import numpy
 
+from . import _compatibility
+
 
 class Box:
     """Triclinic simulation box.
@@ -51,7 +53,9 @@ class Box:
         """
         if isinstance(value, Box):
             return value
-        v = numpy.array(value, ndmin=1, copy=False, dtype=float)
+        v = numpy.array(
+            value, ndmin=1, copy=_compatibility.numpy_copy_if_needed, dtype=float
+        )
         if v.shape == (9,):
             return Box(v[:3], v[3:6], v[6:])
         elif v.shape == (6,):

--- a/src/lammpsio/dump.py
+++ b/src/lammpsio/dump.py
@@ -4,16 +4,13 @@ import pathlib
 
 import numpy
 
+from . import _compatibility
 from .box import Box
 from .data import _readline
 from .snapshot import Snapshot
 
-try:
+if _compatibility.pyzstd_version is not None:
     import pyzstd
-
-    _has_pyzstd = True
-except ModuleNotFoundError:
-    _has_pyzstd = False
 
 
 class DumpFile:
@@ -179,7 +176,7 @@ class DumpFile:
         if suffix == ".gz":
             return gzip
         elif suffix == ".zst":
-            if not _has_pyzstd:
+            if _compatibility.pyzstd_version is None:
                 raise ModuleNotFoundError("pyzstd needed for zstd compression")
             return pyzstd
         else:

--- a/src/lammpsio/snapshot.py
+++ b/src/lammpsio/snapshot.py
@@ -1,15 +1,10 @@
 import warnings
 
 import numpy
-import packaging.version
 
 from . import _compatibility
 from .box import Box
 from .topology import Angles, Bonds, Dihedrals, Impropers
-
-if _compatibility.gsd_version is not None:
-    import gsd
-    import gsd.hoomd
 
 
 class Snapshot:
@@ -129,11 +124,7 @@ class Snapshot:
         if _compatibility.gsd_version is None:
             raise ImportError("GSD package not found")
 
-        # make Frame/Snapshot without deprecation warnings
-        if _compatibility.gsd_version >= packaging.version.Version("2.8.0"):
-            frame = gsd.hoomd.Frame()
-        else:
-            frame = gsd.hoomd.Snapshot()
+        frame = _compatibility.gsd_frame_class()
 
         if self.step is not None:
             frame.configuration.step = int(self.step)

--- a/src/lammpsio/snapshot.py
+++ b/src/lammpsio/snapshot.py
@@ -3,17 +3,13 @@ import warnings
 import numpy
 import packaging.version
 
+from . import _compatibility
 from .box import Box
 from .topology import Angles, Bonds, Dihedrals, Impropers
 
-_optional_imports = set()
-try:
+if _compatibility.gsd_version is not None:
     import gsd
     import gsd.hoomd
-
-    _optional_imports.add("gsd")
-except ImportError:
-    pass
 
 
 class Snapshot:
@@ -130,15 +126,11 @@ class Snapshot:
             Converted HOOMD GSD frame.
 
         """
-        if "gsd" not in _optional_imports:
+        if _compatibility.gsd_version is None:
             raise ImportError("GSD package not found")
 
         # make Frame/Snapshot without deprecation warnings
-        try:
-            gsd_version = gsd.version.version
-        except AttributeError:
-            gsd_version = gsd.__version__
-        if packaging.version.Version(gsd_version) >= packaging.version.Version("2.8.0"):
+        if _compatibility.gsd_version >= packaging.version.Version("2.8.0"):
             frame = gsd.hoomd.Frame()
         else:
             frame = gsd.hoomd.Snapshot()
@@ -228,7 +220,9 @@ class Snapshot:
     @id.setter
     def id(self, value):
         if value is not None:
-            v = numpy.array(value, ndmin=1, copy=False, dtype=int)
+            v = numpy.array(
+                value, ndmin=1, copy=_compatibility.numpy_copy_if_needed, dtype=int
+            )
             if v.shape != (self.N,):
                 raise TypeError("Ids must be a size N array")
             if not self.has_id():
@@ -258,7 +252,9 @@ class Snapshot:
     @position.setter
     def position(self, value):
         if value is not None:
-            v = numpy.array(value, ndmin=2, copy=False, dtype=float)
+            v = numpy.array(
+                value, ndmin=2, copy=_compatibility.numpy_copy_if_needed, dtype=float
+            )
             if v.shape != (self.N, 3):
                 raise TypeError("Positions must be an Nx3 array")
             if not self.has_position():
@@ -288,7 +284,9 @@ class Snapshot:
     @image.setter
     def image(self, value):
         if value is not None:
-            v = numpy.array(value, ndmin=2, copy=False, dtype=int)
+            v = numpy.array(
+                value, ndmin=2, copy=_compatibility.numpy_copy_if_needed, dtype=int
+            )
             if v.shape != (self.N, 3):
                 raise TypeError("Images must be an Nx3 array")
             if not self.has_image():
@@ -318,7 +316,9 @@ class Snapshot:
     @velocity.setter
     def velocity(self, value):
         if value is not None:
-            v = numpy.array(value, ndmin=2, copy=False, dtype=float)
+            v = numpy.array(
+                value, ndmin=2, copy=_compatibility.numpy_copy_if_needed, dtype=float
+            )
             if v.shape != (self.N, 3):
                 raise TypeError("Velocities must be an Nx3 array")
             if not self.has_velocity():
@@ -348,7 +348,9 @@ class Snapshot:
     @molecule.setter
     def molecule(self, value):
         if value is not None:
-            v = numpy.array(value, ndmin=1, copy=False, dtype=int)
+            v = numpy.array(
+                value, ndmin=1, copy=_compatibility.numpy_copy_if_needed, dtype=int
+            )
             if v.shape != (self.N,):
                 raise TypeError("Molecules must be a size N array")
             if not self.has_molecule():
@@ -396,7 +398,9 @@ class Snapshot:
     @typeid.setter
     def typeid(self, value):
         if value is not None:
-            v = numpy.array(value, ndmin=1, copy=False, dtype=int)
+            v = numpy.array(
+                value, ndmin=1, copy=_compatibility.numpy_copy_if_needed, dtype=int
+            )
             if v.shape != (self.N,):
                 raise TypeError("Type must be a size N array")
             if not self.has_typeid():
@@ -426,7 +430,9 @@ class Snapshot:
     @charge.setter
     def charge(self, value):
         if value is not None:
-            v = numpy.array(value, ndmin=1, copy=False, dtype=float)
+            v = numpy.array(
+                value, ndmin=1, copy=_compatibility.numpy_copy_if_needed, dtype=float
+            )
             if v.shape != (self.N,):
                 raise TypeError("Charge must be a size N array")
             if not self.has_charge():
@@ -456,7 +462,9 @@ class Snapshot:
     @mass.setter
     def mass(self, value):
         if value is not None:
-            v = numpy.array(value, ndmin=1, copy=False, dtype=float)
+            v = numpy.array(
+                value, ndmin=1, copy=_compatibility.numpy_copy_if_needed, dtype=float
+            )
             if v.shape != (self.N,):
                 raise TypeError("Mass must be a size N array")
             if not self.has_mass():

--- a/src/lammpsio/topology.py
+++ b/src/lammpsio/topology.py
@@ -1,5 +1,7 @@
 import numpy
 
+from . import _compatibility
+
 
 class Topology:
     """Particle topology.
@@ -44,7 +46,9 @@ class Topology:
     @id.setter
     def id(self, value):
         if value is not None:
-            v = numpy.array(value, ndmin=1, copy=False, dtype=int)
+            v = numpy.array(
+                value, ndmin=1, copy=_compatibility.numpy_copy_if_needed, dtype=int
+            )
             if v.shape != (self.N,):
                 raise TypeError("Ids must be a size N array")
             if not self.has_id():
@@ -74,7 +78,9 @@ class Topology:
     @typeid.setter
     def typeid(self, value):
         if value is not None:
-            v = numpy.array(value, ndmin=1, copy=False, dtype=int)
+            v = numpy.array(
+                value, ndmin=1, copy=_compatibility.numpy_copy_if_needed, dtype=int
+            )
             if v.shape != (self.N,):
                 raise TypeError("typeids must be a size N array")
             if not self.has_typeid():
@@ -104,7 +110,9 @@ class Topology:
     @members.setter
     def members(self, value):
         if value is not None:
-            v = numpy.array(value, ndmin=2, copy=False, dtype=int)
+            v = numpy.array(
+                value, ndmin=2, copy=_compatibility.numpy_copy_if_needed, dtype=int
+            )
             if v.shape != (self.N, self._num_members):
                 raise TypeError("Members must be a size N x number of members array")
             if not self.has_members():

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
-gsd
+gsd<3.3.0; python_version < '3.9'
+gsd; python_version >= '3.9'
 pytest<8
 pytest-lazy-fixture


### PR DESCRIPTION
* Add a `_compatibility` module for handling versioned dependencies
* Fix copy mode for arrays.
* Fix test dependencies for python 3.8.