### PR TITLE
Update test dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,4 +41,4 @@ jobs:
           pip install -r tests/requirements-optin.txt
       - name: Test (optin)
         run: |
-          python -m pytest tests/test_dump_file.py
+          python -m pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from pytest_lazyfixture import lazy_fixture
+from pytest_lazy_fixtures import lf
 
 import lammpsio
 
@@ -14,11 +14,11 @@ def triclinic():
     return lammpsio.Box([-5.0, -10.0, 0.0], [1.0, 10.0, 8.0], [1.0, -2.0, 0.5])
 
 
-@pytest.fixture(params=[lazy_fixture("orthorhombic"), lazy_fixture("triclinic")])
+@pytest.fixture(params=[lf("orthorhombic"), lf("triclinic")])
 def snap(request):
     return lammpsio.Snapshot(3, request.param, 10)
 
 
-@pytest.fixture(params=[lazy_fixture("orthorhombic"), lazy_fixture("triclinic")])
+@pytest.fixture(params=[lf("orthorhombic"), lf("triclinic")])
 def snap_8(request):
     return lammpsio.Snapshot(8, request.param, 10)

--- a/tests/requirements-optin.txt
+++ b/tests/requirements-optin.txt
@@ -1,1 +1,2 @@
+gsd
 pyzstd

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,2 @@
-gsd
-pytest<8
-pytest-lazy-fixture
+pytest>=8
+pytest-lazy-fixtures>=1.1.1


### PR DESCRIPTION
* Use updated `pytest` and `pytest_lazy_fixtures` (replaces `pytest_lazyfixture`... not the `s`)
* Make GSD optional test dependency
* Test for and suppress deprecation warnings