### PR TITLE
Drop Python 3.9, add Python 3.14

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install pip --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -52,15 +52,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        lammps-version: ["2023.08.02", "2024.08.29"]
-        exclude:
-          - python-version: "3.12"
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        lammps-version: ["2024.08.29"]
+        include:
+          - python-version: "3.10"
             lammps-version: "2023.08.02"
-          - python-version: "3.13"
+          - python-version: "3.11"
             lammps-version: "2023.08.02"
-          - python-version: "3.13"
-            lammps-version: "2024.08.29"
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -81,7 +79,7 @@ jobs:
       - name: Test
         run: |
           python -m pytest -m lammps
- # final exit point for unit tests on PRs, which can be a required check
+  # final exit point for unit tests on PRs, which can be a required check
   test-exit:
     name: unit test
     needs: [test, test-lammps]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
-target-version = ["py39"]
+target-version = ["py310"]
 
 [tool.isort]
 profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,18 +15,18 @@ classifiers =
     License :: OSI Approved :: BSD License
     Topic :: Scientific/Engineering :: Chemistry
     Topic :: Scientific/Engineering :: Physics
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
 
 [options]
 packages = find:
 package_dir =
     = src
 include_package_data = True
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
     numpy
     packaging


### PR DESCRIPTION
Python 3.9 is EOL and Python 3.14 was released in October 2025.