### PR TITLE
Support GSD version 5

### DIFF
--- a/src/lammpsio/_compatibility.py
+++ b/src/lammpsio/_compatibility.py
@@ -18,6 +18,13 @@ try:
         gsd_frame_class = gsd.hoomd.Frame
     else:
         gsd_frame_class = gsd.hoomd.Snapshot
+
+    # GSD >= 5.0 validate() does not modify contents in place by default
+    if gsd_version >= packaging.version.Version("5.0.0"):
+        gsd_validate_inplace = True
+    else:
+        gsd_validate_inplace = False
+
 except ModuleNotFoundError:
     gsd_version = None
 

--- a/src/lammpsio/snapshot.py
+++ b/src/lammpsio/snapshot.py
@@ -121,10 +121,9 @@ class Snapshot:
 
         """
         # ensures frame is well formed and that we have NumPy arrays
-        # in gsd >= 5.0 validate() does not modify contents in place by default
-        try:
+        if _compatibility.gsd_validate_inplace:
             frame.validate(inplace=True)
-        except TypeError:
+        else:
             frame.validate()
 
         # process HOOMD box to LAMMPS box

--- a/src/lammpsio/snapshot.py
+++ b/src/lammpsio/snapshot.py
@@ -121,7 +121,11 @@ class Snapshot:
 
         """
         # ensures frame is well formed and that we have NumPy arrays
-        frame.validate()
+        # in gsd >= 5.0 validate() does not modify contents in place by default
+        try:
+            frame.validate(inplace=True)
+        except TypeError:
+            frame.validate()
 
         # process HOOMD box to LAMMPS box
         box = numpy.array(frame.configuration.box, copy=True)


### PR DESCRIPTION
This ensures that GSD v5's new validate behavior works as intended. 